### PR TITLE
Support multiple controllers in one REST UrlRule.

### DIFF
--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -20,8 +20,7 @@ class DefaultController extends \yii\base\Controller
         $rules = [];
         foreach (\Yii::$app->urlManager->rules as $urlRule) {
             if ($urlRule instanceof \yii\rest\UrlRule) {
-                foreach ($urlRule->controller as $urlName => $controllerName)
-                {
+                foreach ($urlRule->controller as $urlName => $controllerName) {
                     $entity = [];
                     $controllerName = strrchr($controllerName, '/') === false ? $controllerName : substr(strrchr($controllerName, '/'), 1);
                     $entity['title'] = ucfirst($controllerName);

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -20,19 +20,20 @@ class DefaultController extends \yii\base\Controller
         $rules = [];
         foreach (\Yii::$app->urlManager->rules as $urlRule) {
             if ($urlRule instanceof \yii\rest\UrlRule) {
-                $entity = [];
-                $urlName = key($urlRule->controller);
-                $controllerName = current($urlRule->controller);
-                $controllerName = strrchr($controllerName, '/') === false ? $controllerName : substr(strrchr($controllerName, '/'), 1);
-                $entity['title'] = ucfirst($controllerName);
-                $urlRuleReflection = new \ReflectionClass($urlRule);
-                $rulesObject = $urlRuleReflection->getProperty('rules');
-                $rulesObject->setAccessible(true);
-                $generatedRules = $rulesObject->getValue($urlRule);
+                foreach ($urlRule->controller as $urlName => $controllerName)
+                {
+                    $entity = [];
+                    $controllerName = strrchr($controllerName, '/') === false ? $controllerName : substr(strrchr($controllerName, '/'), 1);
+                    $entity['title'] = ucfirst($controllerName);
+                    $urlRuleReflection = new \ReflectionClass($urlRule);
+                    $rulesObject = $urlRuleReflection->getProperty('rules');
+                    $rulesObject->setAccessible(true);
+                    $generatedRules = $rulesObject->getValue($urlRule);
 
-                $entity['rules'] = $this->_processRules($generatedRules[$urlName]);
+                    $entity['rules'] = $this->_processRules($generatedRules[$urlName]);
 
-                $rules[] = $entity;
+                    $rules[] = $entity;
+                }
             }
         }
         return $this->render('index', [


### PR DESCRIPTION
Support multiple controllers declared in one single yii\rest\UrlRule.
```php
'rules' => [
    [
        'class' => 'yii\rest\UrlRule',
        'controller' => [
            'endpoint-one',
            'endpoint-two-aliases' => 'endpoint-two',
        ],
    ],
]
```